### PR TITLE
Add model spec and DB default for Task (Task4)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ group :development, :test do
   # 追加
   gem "annotate"
   gem "factory_bot_rails"
-  gem "faker"
   gem "pry-byebug"
   gem "pry-doc"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,8 +91,6 @@ GEM
     factory_bot_rails (6.5.0)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faker (3.5.2)
-      i18n (>= 1.8.11, < 2)
     ffi (1.17.2-aarch64-linux-gnu)
     ffi (1.17.2-aarch64-linux-musl)
     ffi (1.17.2-arm-linux-gnu)
@@ -301,7 +299,6 @@ DEPENDENCIES
   byebug
   erb
   factory_bot_rails
-  faker
   listen (~> 3.7.1)
   pg (~> 1.1)
   pry-byebug

--- a/db/migrate/20250803111900_fix_tasks_constraints.rb
+++ b/db/migrate/20250803111900_fix_tasks_constraints.rb
@@ -1,0 +1,5 @@
+class FixTasksConstraints < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :tasks, :completed, from: nil, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_08_03_033642) do
+ActiveRecord::Schema.define(version: 2025_08_03_111900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 2025_08_03_033642) do
     t.string "title"
     t.text "description"
     t.date "due_date"
-    t.boolean "completed"
+    t.boolean "completed", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :task do
-    title { "MyString" }
-    description { "MyText" }
-    due_date { "2025-08-03" }
+    title { "Test Task" }
+    description { "Test Description" }
+    due_date { "Date.today" }
     completed { false }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,26 @@
 require "rails_helper"
 
 RSpec.describe Task, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "validations" do
+    it "is valid with a title" do
+      task = build(:task)
+      expect(task).to be_valid
+    end
+
+    it "is invalid without a title" do
+      task = build(:task, title: nil)
+      expect(task).not_to be_valid
+    end
+
+    it "adds an error message when title is blank" do
+      task = build(:task, title: nil)
+      task.valid?
+      expect(task.errors[:title]).to include("can't be blank")
+    end
+
+    it "defaults completed to false" do
+      task = Task.new(title: "Test Task")
+      expect(task.completed).to be false
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -60,4 +60,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include FactoryBot::Syntax::Methods
 end


### PR DESCRIPTION
## Context
Implements RSpec tests for `Task` model validation and sets default value for `completed` field at the DB level.

## Changes
- Added model spec for `Task`
  - Validates presence of `title`
  - Confirms default `completed: false`
- Included `FactoryBot::Syntax::Methods` in RSpec
- Removed unused `pending` test block
- Added DB migration to set `completed` default to `false`
- Rubocop passed
- Updated `FactoryBot` definition for Task (more realistic default values)

## Git-Flow
`feature/Task4-model-spec` → `develop`