### PR TITLE
Add: TaskSerializer and response structure (Task5)

### DIFF
--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -1,0 +1,3 @@
+class TaskSerializer < ActiveModel::Serializer
+  attributes :id, :title, :description, :due_date, :completed, :created_at, :updated_at
+end


### PR DESCRIPTION
## Context
Define the JSON response structure for the Task model to standardize API outputs and support frontend integration.

## Changes
- Implemented `TaskSerializer` with attributes:
  - id
  - title
  - description
  - due_date
  - completed
  - created_at
  - updated_at

## Notes
This serializer will be applied in the `index` and `show` endpoints during Task6 implementation.  
All responses are formatted via ActiveModel::Serializer (AMS) to ensure consistency.

## Git-Flow
`feature/Task5-response_design` → `develop`