### PR TITLE
Add: TaskController#index/show and request specs (Task6-1)

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -1,0 +1,17 @@
+module Api
+  module V1
+    class TasksController < ApplicationController
+      def index
+        tasks = Task.all.order(created_at: :desc)
+        render json: tasks
+      end
+
+      def show
+        task = Task.find(params[:id])
+        render json: task
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "Task not found" }, status: :not_found
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      resources :tasks, only: [:index, :show]
+    end
+  end
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -60,3 +60,6 @@ RSpec/NestedGroups:
 # ブロックの方が見た目がスッキリして見やすいので、どちらでもお好きにどうぞ。
 RSpec/ReturnFromStub:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Max: 8

--- a/spec/requests/api/v1/tasks_spec.rb
+++ b/spec/requests/api/v1/tasks_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Tasks", type: :request do
+  describe "GET /index" do
+    it "returns all tasks with correct structure" do
+      create_list(:task, 3)
+      get "/api/v1/tasks"
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json.size).to eq(3)
+      expect(json.first.keys).to contain_exactly("id", "title", "description", "due_date", "completed", "created_at", "updated_at")
+    end
+  end
+
+  describe "GET /show" do
+    let(:task) { create(:task) }
+
+    it "returns the task with correct structure" do
+      get "/api/v1/tasks/#{task.id}"
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["id"]).to eq(task.id)
+      expect(json.keys).to contain_exactly("id", "title", "description", "due_date", "completed", "created_at", "updated_at")
+    end
+
+    it "returns 404 if task not found" do
+      non_existing_id = Task.maximum(:id).to_i + 1
+      get "/api/v1/tasks/#{non_existing_id}"
+      expect(response).to have_http_status(:not_found)
+      json = JSON.parse(response.body)
+      expect(json["error"]).to eq("Task not found")
+    end
+  end
+end


### PR DESCRIPTION
## Context
Implement read endpoints (`index`, `show`) for the Task API using `TaskSerializer` to deliver structured JSON responses.  
This provides a consistent interface for frontend consumption and ensures test coverage for core API responses.

## Changes
- Implemented `TasksController` with `index` and `show` actions
- Added routing under `/api/v1/tasks`
- Applied `TaskSerializer` to format API responses
- Wrote request specs to validate response structure and status codes

## Notes
- Response fields: `id`, `title`, `description`, `due_date`, `completed`, `created_at`, `updated_at`
  - Note: `created_at` and `updated_at` are currently unused on the frontend, but retained for potential future use (e.g., sorting or displaying history). Let me know if you'd prefer to remove them.
- 404 handling included in `show`
- Prepares structure for future `create/update/destroy` operations
- Allow** up to 8 expectations per example in RSpec (Rubocop `MultipleExpectations` rule updated)

## Git-Flow
`feature/Task6-1-index-show` → `develop`