### PR TITLE
Chore: Add schema annotation and move annotate gem to development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   # 追加
-  gem "annotate"
   gem "factory_bot_rails"
   gem "pry-byebug"
   gem "pry-doc"
@@ -43,6 +42,7 @@ group :development do
   gem "listen", "~> 3.7.1"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # gem 'spring'
+  gem "annotate"
   gem "erb"
   gem "rails-erd"
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id          :bigint           not null, primary key
+#  title       :string
+#  description :text
+#  due_date    :date
+#  completed   :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class Task < ApplicationRecord
   validates :title, presence: true
 end

--- a/app/serializers/task_serializer.rb
+++ b/app/serializers/task_serializer.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id          :bigint           not null, primary key
+#  title       :string
+#  description :text
+#  due_date    :date
+#  completed   :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class TaskSerializer < ActiveModel::Serializer
   attributes :id, :title, :description, :due_date, :completed, :created_at, :updated_at
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id          :bigint           not null, primary key
+#  title       :string
+#  description :text
+#  due_date    :date
+#  completed   :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
   factory :task do
     title { "Test Task" }

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id          :bigint           not null, primary key
+#  title       :string
+#  description :text
+#  due_date    :date
+#  completed   :boolean          default(FALSE)
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 require "rails_helper"
 
 RSpec.describe Task, type: :model do


### PR DESCRIPTION
# Context
As part of Task6-2, minor adjustments were made to improve clarity and maintainability.

## Changes
- Ran `annotate` to include schema comments in Task model
- Moved `annotate` gem from `development/test` to `development` only

## Notes
No logic or feature changes. Task6-2 is still in progress and continues separately.

## Git-Flow
`chore/annotate-and-gem-cleanup` → `develop`
