### PR TITLE
Add: create/update/destroy actions for Task API (Task6-2)

### DIFF
--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -12,6 +12,21 @@ module Api
       rescue ActiveRecord::RecordNotFound
         render json: { error: "Task not found" }, status: :not_found
       end
+
+      def create
+        task = Task.new(task_params)
+        if task.save
+          render json: task, status: :created
+        else
+          render json: task.errors, status: :unprocessable_entity
+        end
+      end
+
+      private
+
+        def task_params
+          params.require(:task).permit(:title, :description, :due_date, :completed)
+        end
     end
   end
 end

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -33,6 +33,14 @@ module Api
         render json: { error: "Task not found" }, status: :not_found
       end
 
+      def destroy
+        task = Task.find(params[:id])
+        task.destroy!
+        head :no_content
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "Task not found" }, status: :not_found
+      end
+
       private
 
         def task_params

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -22,6 +22,17 @@ module Api
         end
       end
 
+      def update
+        task = Task.find(params[:id])
+        if task.update(task_params)
+          render json: task
+        else
+          render json: task.errors, status: :unprocessable_entity
+        end
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "Task not found" }, status: :not_found
+      end
+
       private
 
         def task_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :tasks, only: [:index, :show]
+      resources :tasks
     end
   end
 end

--- a/spec/requests/api/v1/tasks_spec.rb
+++ b/spec/requests/api/v1/tasks_spec.rb
@@ -85,4 +85,24 @@ RSpec.describe "Api::V1::Tasks", type: :request do
       expect(json["title"]).to include("can't be blank")
     end
   end
+
+  describe "DELETE /destroy" do
+    let!(:task) { create(:task) }
+    let(:non_existing_id) { Task.maximum(:id).to_i + 1 }
+
+    it "deletes the task" do
+      delete "/api/v1/tasks/#{task.id}"
+
+      expect(response).to have_http_status(:no_content)
+      expect(Task).not_to exist(task.id)
+    end
+
+    it "returns 404 if task not found" do
+      delete "/api/v1/tasks/#{non_existing_id}"
+
+      expect(response).to have_http_status(:not_found)
+      json = JSON.parse(response.body)
+      expect(json["error"]).to eq("Task not found")
+    end
+  end
 end

--- a/spec/requests/api/v1/tasks_spec.rb
+++ b/spec/requests/api/v1/tasks_spec.rb
@@ -56,4 +56,33 @@ RSpec.describe "Api::V1::Tasks", type: :request do
       expect(json["title"]).to include("can't be blank")
     end
   end
+
+  describe "PUT /update" do
+    let(:task) { create(:task, title: "Old Title") }
+
+    it "updates the task with correct structure" do
+      put "/api/v1/tasks/#{task.id}", params: { task: { title: "Updated Title" } }
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["title"]).to eq("Updated Title")
+      expect(json.keys).to contain_exactly("id", "title", "description", "due_date", "completed", "created_at", "updated_at")
+    end
+
+    it "returns 404 if task not found" do
+      put "/api/v1/tasks/9999", params: { task: { title: "Whatever" } }
+
+      expect(response).to have_http_status(:not_found)
+      json = JSON.parse(response.body)
+      expect(json["error"]).to eq("Task not found")
+    end
+
+    it "returns error when title is blank" do
+      put "/api/v1/tasks/#{task.id}", params: { task: { title: "" } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json["title"]).to include("can't be blank")
+    end
+  end
 end

--- a/spec/requests/api/v1/tasks_spec.rb
+++ b/spec/requests/api/v1/tasks_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "Api::V1::Tasks", type: :request do
 
   describe "GET /show" do
     let(:task) { create(:task) }
+    let(:non_existing_id) { Task.maximum(:id).to_i + 1 }
 
     it "returns the task with correct structure" do
       get "/api/v1/tasks/#{task.id}"
@@ -26,11 +27,33 @@ RSpec.describe "Api::V1::Tasks", type: :request do
     end
 
     it "returns 404 if task not found" do
-      non_existing_id = Task.maximum(:id).to_i + 1
       get "/api/v1/tasks/#{non_existing_id}"
       expect(response).to have_http_status(:not_found)
       json = JSON.parse(response.body)
       expect(json["error"]).to eq("Task not found")
+    end
+  end
+
+  describe "POST /create" do
+    it "creates a task with correct structure" do
+      valid_params = { task: { title: "New Task" } }
+
+      post "/api/v1/tasks", params: valid_params
+
+      expect(response).to have_http_status(:created)
+      json = JSON.parse(response.body)
+      expect(json["title"]).to eq("New Task")
+      expect(json.keys).to contain_exactly("id", "title", "description", "due_date", "completed", "created_at", "updated_at")
+    end
+
+    it "returns error when title is missing" do
+      invalid_params = { task: { title: "" } }
+
+      post "/api/v1/tasks", params: invalid_params
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      json = JSON.parse(response.body)
+      expect(json["title"]).to include("can't be blank")
     end
   end
 end


### PR DESCRIPTION
## Context
Implements the remaining API actions (`create`, `update`, `destroy`) for Task management.  
This PR focuses solely on these actions and does not involve index/show.

## Changes
- Implemented `create`, `update`, and `destroy` in `Api::V1::TasksController`
- Added routing for the new actions (expanded `resources :tasks`)
- Included parameter handling and consistent error responses
- Added request specs for all 3 endpoints

## Notes
- All actions return raw JSON responses (no Serializer used)
- Unified error handling using `Task.find` with `rescue ActiveRecord::RecordNotFound`
- Model validations enforce title presence
- Request specs verify both success and failure cases with response structure

## Git-Flow
`feature/Task6-2-crud` → `develop`